### PR TITLE
Fix color of meta <link> tag angle brackets

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -173,7 +173,7 @@
   }
 
   &.syntax--link {
-    color: @orange;
+    color: @syntax-text-color;
   }
 
   &.syntax--require {


### PR DESCRIPTION
Small fix to set the color of the brackets to normal text color instead of orange.